### PR TITLE
[Emogrifier] Update integration

### DIFF
--- a/src/EmailizrBundle/Parser/InlineStyleParser.php
+++ b/src/EmailizrBundle/Parser/InlineStyleParser.php
@@ -2,30 +2,21 @@
 
 namespace EmailizrBundle\Parser;
 
-use Pelago\Emogrifier;
+use Pelago\Emogrifier\CssInliner;
 use Pimcore\Http\Request\Resolver\EditmodeResolver;
 
 class InlineStyleParser
 {
-    /**
-     * @var Emogrifier
-     */
-    protected $emogrifier;
-
     /**
      * @var EditmodeResolver
      */
     protected $editmodeResolver;
 
     /**
-     * EmailParser constructor.
-     *
-     * @param Emogrifier       $emogrifier
      * @param EditmodeResolver $editmodeResolver
      */
-    public function __construct(Emogrifier $emogrifier, EditmodeResolver $editmodeResolver)
+    public function __construct(EditmodeResolver $editmodeResolver)
     {
-        $this->emogrifier = $emogrifier;
         $this->editmodeResolver = $editmodeResolver;
     }
 
@@ -42,13 +33,12 @@ class InlineStyleParser
             return $html;
         }
 
-        $this->emogrifier->setHtml($html);
-        $this->emogrifier->setCss($css);
+        $inliner = CssInliner::fromHtml($html)->inlineCss($css);
 
         if ($onlyBodyContent) {
-            $mergedHtml = $this->emogrifier->emogrifyBodyContent();
+            $mergedHtml = $inliner->renderBodyContent();
         } else {
-            $mergedHtml = $this->emogrifier->emogrify();
+            $mergedHtml = $inliner->render();
         }
 
         //replace %DataObject(member_id,%7B'method'%20:%20'getResetHash'%7D); placeholder

--- a/src/EmailizrBundle/Resources/config/services/library.yml
+++ b/src/EmailizrBundle/Resources/config/services/library.yml
@@ -1,9 +1,0 @@
-services:
-
-    _defaults:
-        autowire: false
-        autoconfigure: false
-        public: false
-
-    Pelago\Emogrifier:
-        public: false

--- a/tests/unit/InlineStyleParserTest.php
+++ b/tests/unit/InlineStyleParserTest.php
@@ -4,7 +4,6 @@ namespace DachcomBundle\Test\unit;
 
 use DachcomBundle\Test\Test\DachcomBundleTestCase;
 use EmailizrBundle\Parser\InlineStyleParser;
-use Pelago\Emogrifier;
 use Pimcore\Http\Request\Resolver\EditmodeResolver;
 
 class InlineStyleParserTest extends DachcomBundleTestCase
@@ -23,7 +22,7 @@ class InlineStyleParserTest extends DachcomBundleTestCase
             ->method('isEditmode')
             ->willReturn(false);
 
-        $this->inlineStyleParser = new InlineStyleParser(new Emogrifier(), $editmodeResolver);
+        $this->inlineStyleParser = new InlineStyleParser($editmodeResolver);
     }
 
     public function testParseInlineHtml()

--- a/tests/unit/TwigInlineStyleExtensionTest.php
+++ b/tests/unit/TwigInlineStyleExtensionTest.php
@@ -7,7 +7,6 @@ use EmailizrBundle\Parser\InlineStyleParser;
 use EmailizrBundle\Twig\Extension\InkyExtension;
 use EmailizrBundle\Twig\Extension\InlineStyleExtension;
 use EmailizrBundle\Twig\Parser\InlineStyleTokenParser;
-use Pelago\Emogrifier;
 use Pimcore\Http\Request\Resolver\EditmodeResolver;
 use Symfony\Component\HttpKernel\Config\FileLocator;
 use Twig\TwigFunction;
@@ -28,7 +27,7 @@ class TwigInlineStyleExtensionTest extends DachcomBundleTestCase
             ->method('isEditmode')
             ->willReturn(false);
 
-        $inlineStyleParser = new InlineStyleParser(new Emogrifier(), $editmodeResolver);
+        $inlineStyleParser = new InlineStyleParser($editmodeResolver);
 
         $this->extension = new InlineStyleExtension($inlineStyleParser, $fileLocator);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes

This PR replaces the deprecated `Emogrifier` class with the recommended `CssInliner` class provided by the emogrifier package. This is a PR to prepare Emailizr to receive the latest CSS inlining features from Emogrifier (see e.g. https://github.com/MyIntervals/emogrifier/issues/869).
