### PR TITLE
[Emogrifier] Upgrade package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "pimcore/pimcore": "^5.4.0 | ^6.3.0",
         "lorenzo/pinky":"^1.0.3",
-        "pelago/emogrifier": "^3.1.0"
+        "pelago/emogrifier": "^4.0"
     },
     "require-dev": {
         "codeception/codeception": "~2.3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

With this PR it is possible to retrieve the latest versions of the emogrifier package, since they [released v4](https://github.com/MyIntervals/emogrifier/releases/tag/v4.0.0). Since we're using the [`CssInliner` class already](https://github.com/dachcom-digital/pimcore-emailizr/pull/20), no other changes are required.
