### PR TITLE
add twig >= 3.9 (only) suppport

### DIFF
--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -1,9 +1,9 @@
 name: Codeception
 on:
     push:
-        branches: [ 'master' ]
+        branches: [ '2.x' ]
     pull_request:
-        branches: [ 'master' ]
+        branches: [ '2.x' ]
 
 jobs:
     codeception:
@@ -123,6 +123,7 @@ jobs:
                     TEST_PIMCORE_VERSION: ${{ matrix.pimcore }}
                     TEST_SYMFONY_VERSION: ${{ matrix.symfony }}
                 run: |
+                    sed -i 's|"require-dev": {|"conflict": {"league/csv": ">=9.11.0"},\n "require-dev": {|' ${{ github.workspace }}/lib/test-bundle/composer.json
                     chmod +x ./pimcore-codeception-framework/src/_etc/scripts/composer.sh
                     ./pimcore-codeception-framework/src/_etc/scripts/composer.sh
 

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -1,9 +1,9 @@
 name: Easy Coding Standards
 on:
     push:
-        branches: [ 'master' ]
+        branches: [ '2.x' ]
     pull_request:
-        branches: [ 'master' ]
+        branches: [ '2.x' ]
 
 jobs:
     ecs:
@@ -103,6 +103,7 @@ jobs:
                     TEST_PIMCORE_VERSION: ${{ matrix.pimcore }}
                     TEST_SYMFONY_VERSION: ${{ matrix.symfony }}
                 run: |
+                    sed -i 's|"require-dev": {|"conflict": {"league/csv": ">=9.11.0"},\n "require-dev": {|' ${{ github.workspace }}/lib/test-bundle/composer.json
                     chmod +x ./pimcore-codeception-framework/src/_etc/scripts/composer.sh
                     ./pimcore-codeception-framework/src/_etc/scripts/composer.sh
 

--- a/.github/workflows/php-stan.yml
+++ b/.github/workflows/php-stan.yml
@@ -1,9 +1,9 @@
 name: PHP Stan
 on:
     push:
-        branches: [ 'master' ]
+        branches: [ '2.x' ]
     pull_request:
-        branches: [ 'master' ]
+        branches: [ '2.x' ]
 
 jobs:
     stan:
@@ -103,6 +103,7 @@ jobs:
                     TEST_PIMCORE_VERSION: ${{ matrix.pimcore }}
                     TEST_SYMFONY_VERSION: ${{ matrix.symfony }}
                 run: |
+                    sed -i 's|"require-dev": {|"conflict": {"league/csv": ">=9.11.0"},\n "require-dev": {|' ${{ github.workspace }}/lib/test-bundle/composer.json
                     chmod +x ./pimcore-codeception-framework/src/_etc/scripts/composer.sh
                     ./pimcore-codeception-framework/src/_etc/scripts/composer.sh
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ### Requirements
 * Pimcore >= 10.1.0
 * PHP >= 8.0
+* Twig >= 3.9
 
 ### Release Plan
 
@@ -21,7 +22,7 @@
 
 ```json
 "require" : {
-    "dachcom-digital/emailizr" : "~2.0.0",
+    "dachcom-digital/emailizr" : "~2.1.0",
 }
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade Notes
 
+## Version 2.1
+- Remove Pimcore 11 Support (use Emailizr 3.x instead)
+- Starting with 2.1, Emailizr only supports Twig 3.9
+
 ## Version 2.0.3
 - Allow `pelago/emogrifier:^7.0`
 - Bump `lorenzo/pinky` to `1.0.9`

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         }
     },
     "require": {
-        "pimcore/pimcore": "^10.1 || ^11.0",
+        "pimcore/pimcore": "^10.1",
+        "twig/twig": "^3.9",
         "lorenzo/pinky": "^1.0.9",
         "pelago/emogrifier": "^4.0 | ^5.0 | ^6.0 | ^7.0"
     },

--- a/src/EmailizrBundle/Twig/Node/InlineStyleNode.php
+++ b/src/EmailizrBundle/Twig/Node/InlineStyleNode.php
@@ -2,27 +2,48 @@
 
 namespace EmailizrBundle\Twig\Node;
 
+use Twig\Attribute\YieldReady;
 use Twig\Compiler;
+use Twig\Node\CaptureNode;
 use Twig\Node\Node;
 
+#[YieldReady]
 class InlineStyleNode extends Node
 {
-    public function __construct(Node $html, int $line = 0, string $tag = 'inline_style')
+    public function __construct(Node $html, int $lineno, string $tag)
     {
-        parent::__construct(['html' => $html], [], $line, $tag);
+        parent::__construct(['html' => $html], [], $lineno, $tag);
     }
 
     public function compile(Compiler $compiler): void
     {
+        $node = new CaptureNode(
+            $this->getNode('html'),
+            $this->getNode('html')->lineno,
+            $this->getNode('html')->tag
+        );
+
+        $node->setAttribute('with_blocks', true);
+
         $compiler
-            ->write("ob_start();\n")
-            ->subcompile($this->getNode('html'))
-            ->write('$zurbCss = "";')
-            ->write('foreach($context["emailizr_style_collector"] as $cssFile){')
-            ->write('$path = $context["emailizr_locator"]->locate($cssFile);')
-            ->write('if($path){$zurbCss .= "\n".file_get_contents($path);}')
-            ->write('}')
-            ->write('echo $context["emailizr_inline_style_parser"]->parseInlineHtml(ob_get_clean(), $zurbCss);')
-            ->write('$context["emailizr_style_collector"]->removeAll();');
+            ->write(sprintf('$inlineCssFiles = "";%s', PHP_EOL))
+            ->write(sprintf('foreach($context["emailizr_style_collector"] as $cssFile) {%s', PHP_EOL))
+            ->indent()
+            ->write(sprintf('$path = $context["emailizr_locator"]->locate($cssFile);%s', PHP_EOL))
+            ->write(sprintf('if ($path) {%s', PHP_EOL))
+            ->indent()
+            ->write(sprintf('$inlineCssFiles .= "\n".file_get_contents($path);%s', PHP_EOL))
+            ->outdent()
+            ->write(sprintf('}%s', PHP_EOL))
+            ->outdent()
+            ->write(sprintf('}%1$s%1$s', PHP_EOL))
+
+            ->write(sprintf('$%s = ', 'inlineHtml'))
+            ->subcompile($node)
+            ->raw(sprintf('%s', PHP_EOL))
+
+            ->write(sprintf('%1$s%1$s', PHP_EOL))
+            ->write(sprintf('yield $context["emailizr_inline_style_parser"]->parseInlineHtml($inlineHtml, $inlineCssFiles);%s', PHP_EOL))
+            ->write(sprintf('$context["emailizr_style_collector"]->removeAll();%1$s%1$s', PHP_EOL));
     }
 }

--- a/src/EmailizrBundle/Twig/Parser/InlineStyleTokenParser.php
+++ b/src/EmailizrBundle/Twig/Parser/InlineStyleTokenParser.php
@@ -16,8 +16,7 @@ class InlineStyleTokenParser extends AbstractTokenParser
      */
     public function parse(Token $token): InlineStyleNode
     {
-        $parser = $this->parser;
-        $stream = $parser->getStream();
+        $stream = $this->parser->getStream();
         $stream->expect(Token::BLOCK_END_TYPE);
         $html = $this->parser->subparse([$this, 'decideEnd'], true);
         $stream->expect(Token::BLOCK_END_TYPE);


### PR DESCRIPTION
| Q             | A                                                  |
|---------------|----------------------------------------------------|
| Bug fix?      | yes                                             |
| New feature?  | yes                                             |
| BC breaks?    | no                                                 |
| Deprecations? | no                                             |
| Fixed tickets | #45 

- Remove Pimcore 11 Support (use Emailizr 3.x instead)
- Starting with 2.1, Emailizr only supports Twig 3.9


