### PR TITLE
[P11] add twig >= 3.9 (only) suppport

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ### Requirements
 * Pimcore: ^11.0
 * PHP: >= 8.1
+* Twig >= 3.9
 
 ### Release Plan
 
@@ -22,7 +23,7 @@
 
 ```json
 "require" : {
-    "dachcom-digital/emailizr" : "~3.0.0",
+    "dachcom-digital/emailizr" : "~3.1.0",
 }
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,7 @@
 # Upgrade Notes
---
+
+## Version 3.1
+Starting with 3.1, Emailizr only supports Twig 3.9
 
 ## Migrating from Version 2.x to Version 3.0.0
 - Pimcore 11.0 support only

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require": {
         "pimcore/pimcore": "^11.0",
+        "twig/twig": "^3.9",
         "twig/inky-extra": "^3.0",
         "pelago/emogrifier": "^7.0"
     },

--- a/src/Twig/Node/InlineStyleNode.php
+++ b/src/Twig/Node/InlineStyleNode.php
@@ -2,9 +2,12 @@
 
 namespace EmailizrBundle\Twig\Node;
 
+use Twig\Attribute\YieldReady;
 use Twig\Compiler;
+use Twig\Node\CaptureNode;
 use Twig\Node\Node;
 
+#[YieldReady]
 class InlineStyleNode extends Node
 {
     public function __construct(Node $html, int $line = 0, string $tag = 'inline_style')
@@ -14,15 +17,30 @@ class InlineStyleNode extends Node
 
     public function compile(Compiler $compiler): void
     {
+        $node = new CaptureNode(
+            $this->getNode('html'),
+            $this->getNode('html')->lineno,
+            $this->getNode('html')->tag
+        );
+
+        $node->setAttribute('with_blocks', true);
+
         $compiler
-            ->write("ob_start();\n")
-            ->subcompile($this->getNode('html'))
-            ->write('$zurbCss = "";')
-            ->write('foreach($context["emailizr_style_collector"] as $cssFile){')
-            ->write('$path = $context["emailizr_locator"]->locate($cssFile);')
-            ->write('if($path){$zurbCss .= "\n".file_get_contents($path);}')
-            ->write('}')
-            ->write('echo $context["emailizr_inline_style_parser"]->parseInlineHtml(ob_get_clean(), $zurbCss);')
-            ->write('$context["emailizr_style_collector"]->removeAll();');
+            ->write(sprintf('$inlineCssFiles = "";%s', PHP_EOL))
+            ->write(sprintf('foreach($context["emailizr_style_collector"] as $cssFile) {%s', PHP_EOL))
+            ->indent()
+            ->write(sprintf('$path = $context["emailizr_locator"]->locate($cssFile);%s', PHP_EOL))
+            ->write(sprintf('if ($path) {%s', PHP_EOL))
+            ->indent()
+            ->write(sprintf('$inlineCssFiles .= "\n".file_get_contents($path);%s', PHP_EOL))
+            ->outdent()
+            ->write(sprintf('}%s', PHP_EOL))
+            ->outdent()
+            ->write(sprintf('}%1$s%1$s', PHP_EOL))
+            ->write(sprintf('$%s = ', 'inlineHtml'))
+            ->subcompile($node)
+            ->raw(sprintf('%1$s%1$s', PHP_EOL))
+            ->write(sprintf('yield $context["emailizr_inline_style_parser"]->parseInlineHtml($inlineHtml, $inlineCssFiles);%s', PHP_EOL))
+            ->write(sprintf('$context["emailizr_style_collector"]->removeAll();%1$s%1$s', PHP_EOL));
     }
 }


### PR DESCRIPTION
| Q             | A                                                  |
|---------------|----------------------------------------------------|
| Bug fix?      | yes                                             |
| New feature?  | yes                                             |
| BC breaks?    | no                                                 |
| Deprecations? | no                                             |
| Fixed tickets | #45 

Starting with 3.1, Emailizr only supports Twig 3.9