### PR TITLE
Compatibility with Pimcore >= 11.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "pimcore/pimcore": "^11.0",
-        "twig/twig": "^3.9",
+        "twig/twig": "^3.8",
         "twig/inky-extra": "^3.0",
         "pelago/emogrifier": "^7.0"
     },


### PR DESCRIPTION
| Q             | A                                                  |
|---------------|----------------------------------------------------|
| Bug fix?      | yes                                            |
| New feature?  | no                                             |
| BC breaks?    | no                                                 |
| Deprecations? |no                                             |

Pimcore has added
> "conflict": {
    "twig/twig": ">=3.9.0"
  },

in https://github.com/pimcore/pimcore/blob/6b384646c47c471916974b79186d6e8766dcac14/composer.json#L136

Thus currently this library does not work with latest Pimcore version.
Do we absolutely need latest version of `twig/twig` or is 3.8 also ok?